### PR TITLE
fix(package): adding gulp-footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp": "^3.9.0",
     "gulp-concat": "^2.5.2",
     "gulp-filter": "^3.0.1",
+    "gulp-footer": "^1.0.5",
     "gulp-header": "^1.2.2",
     "gulp-iife": "^0.2.4",
     "gulp-jscs": "^3.0.0",


### PR DESCRIPTION
gulp-footer is required in `gulpfile.js` but was not referenced as a dev-dependency